### PR TITLE
add pagination support to apis

### DIFF
--- a/webset/services/websetService.py
+++ b/webset/services/websetService.py
@@ -96,16 +96,44 @@ def create_webset(query):
     return items.data
 
 
-def get_webset(webset_id):
-    webset = exa.websets.get(webset_id)
+def get_webset(webset_id, requested_page_no=1, limit=1):
+    paged_webset_items = get_paged_webset(webset_id, requested_page_no,limit)
 
-
+    if paged_webset_items:
+      for item in paged_webset_items.data:
+        print(f"Item: {item.model_dump_json(indent=2)}")
+      return paged_webset_items.data
+    return None
     # Wait until Webset completes processing
     #webset = exa.websets.wait_until_idle(webset.id)
 
-    # Retrieve Webset Items
-    items = exa.websets.items.list(webset_id=webset_id)
-    for item in items.data:
-        print(f"Item: {item.model_dump_json(indent=2)}")
+    # # Retrieve Webset Items
+    # items = exa.websets.items.list(webset_id=webset_id)
+    # # Get page number
+    # # import pdb; pdb.set_trace()
+    # for item in items.data:
+    #     print(f"Item: {item.model_dump_json(indent=2)}")
 
-    return items.data
+    # return items.data
+
+def get_paged_webset(webset_id, requested_page_no=1, limit=1):
+    webset = exa.websets.get(webset_id)
+
+    current_page = 1
+    cursor=None
+
+    while True:
+      items = exa.websets.items.list(
+        webset_id=webset_id,
+          limit=limit,
+          cursor=cursor
+      )
+
+      cursor = items.next_cursor
+
+      if current_page == requested_page_no:
+        return items
+      current_page = current_page + 1
+    
+      if items.next_cursor == None:
+         return None

--- a/webset/views/webset.py
+++ b/webset/views/webset.py
@@ -37,9 +37,12 @@ def create_webset(request):
 
 
 def get_webset(request,webset_id):
+    page = int(request.GET.get("page") or 1)
+    limit = int(request.GET.get("limit") or 5)
+
     if request.method == "GET":
         # TO BE CHECKED
-        result = websetService.get_webset(webset_id)
+        result = websetService.get_webset(webset_id, requested_page_no=page, limit=limit)
         if result:
             response = {
                 "success": True,


### PR DESCRIPTION
This PR introduces pagination support to the Webset API, allowing user to request data in chunks via query parameters. This improves performance and usability when working with large results.

How to use:
{{baseurl}}/websets/get/<webset_id>?page=1&limit=5